### PR TITLE
[IMP] cambia las eqtiquetas restantes de openerp a odoo y cambia el nombre del archivo descriptor del modulo

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Localización Venezolana: Municipios y Parroquias",
+    "version": "10.0.2",
+    "author": "BachacoVE",
+    "category": "Localization",
+    "description":
+        """
+Localización Venezolana: Municipios y Parroquias
+================================================
+
+Basado en información del INE del año 2013, añade los campos de municipio y parroquia en el modelo `res.partner` de
+manera que queden disponibles en todos los campos de dirección en modelos derivados como `res.users` o `res.company`.
+     """,
+    "maintainer": "BachacoVE",
+    "website": "http://www.bachaco.org.ve",
+	'images': ['static/description/icon.png'],
+    "depends": ['base', ],
+    "init_xml": [],
+    "demo_xml": [],
+    "data": [
+
+        'data/res.country.state.xml',
+        'data/res.country.state.municipality.xml',
+        'data/res.country.state.municipality.parish.xml',
+        'views/l10n_ve_dpt_view.xml',
+        'views/res_partner.xml',
+        'security/ir.model.access.csv'
+    ],
+    "installable": True
+}

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -1,4 +1,4 @@
-from openerp import models, fields, api
+from odoo import models, fields, api
 
 class res_partner(models.Model):
 

--- a/views/res_partner.xml
+++ b/views/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<openerp>
+<odoo>
     <data>
 
         <record id="res_partner_view_municipality_parish" model="ir.ui.view">
@@ -15,4 +15,4 @@
         </record>
 
     </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
cambia las etiquetas y demas referencias remanentes a openerp por las de odoo, acorde con los lineamiento de odoo 10 